### PR TITLE
Update app navigation to new design

### DIFF
--- a/app/src/androidTest/java/com/app/whakaara/bottomsheet/BottomSheetAlarmDetailsTest.kt
+++ b/app/src/androidTest/java/com/app/whakaara/bottomsheet/BottomSheetAlarmDetailsTest.kt
@@ -9,7 +9,7 @@ import androidx.compose.ui.test.onNodeWithTag
 import androidx.compose.ui.test.onNodeWithText
 import com.app.whakaara.state.BooleanStateEvent
 import com.app.whakaara.state.StringStateEvent
-import com.app.whakaara.ui.bottomsheet.BottomSheetAlarmDetails
+import com.app.whakaara.ui.bottomsheet.details.BottomSheetAlarmDetails
 import com.app.whakaara.ui.theme.WhakaaraTheme
 import org.junit.Rule
 import org.junit.Test

--- a/app/src/androidTest/java/com/app/whakaara/bottomsheet/BottomSheetTimePickerTest.kt
+++ b/app/src/androidTest/java/com/app/whakaara/bottomsheet/BottomSheetTimePickerTest.kt
@@ -4,7 +4,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithText
 import com.app.whakaara.state.HoursUpdateEvent
-import com.app.whakaara.ui.bottomsheet.BottomSheetTimePicker
+import com.app.whakaara.ui.bottomsheet.details.BottomSheetTimePicker
 import com.app.whakaara.ui.theme.WhakaaraTheme
 import com.chargemap.compose.numberpicker.FullHours
 import org.junit.Rule

--- a/app/src/androidTest/java/com/app/whakaara/bottomsheet/BottomSheetTopBarTest.kt
+++ b/app/src/androidTest/java/com/app/whakaara/bottomsheet/BottomSheetTopBarTest.kt
@@ -6,7 +6,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.compose.ui.test.onNodeWithText
 import com.app.whakaara.data.alarm.Alarm
-import com.app.whakaara.ui.bottomsheet.BottomSheetTopBar
+import com.app.whakaara.ui.bottomsheet.details.BottomSheetDetailsTopBar
 import com.app.whakaara.ui.theme.WhakaaraTheme
 import com.chargemap.compose.numberpicker.FullHours
 import com.dokar.sheets.BottomSheetState
@@ -23,7 +23,7 @@ class BottomSheetTopBarTest {
         // Given + When
         setContent {
             WhakaaraTheme {
-                BottomSheetTopBar(
+                BottomSheetDetailsTopBar(
                     coroutineScope = rememberCoroutineScope(),
                     sheetState = BottomSheetState(),
                     alarm = Alarm(

--- a/app/src/main/java/com/app/whakaara/ui/bottomsheet/details/BottomSheetAlarmDetails.kt
+++ b/app/src/main/java/com/app/whakaara/ui/bottomsheet/details/BottomSheetAlarmDetails.kt
@@ -1,4 +1,4 @@
-package com.app.whakaara.ui.bottomsheet
+package com.app.whakaara.ui.bottomsheet.details
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column

--- a/app/src/main/java/com/app/whakaara/ui/bottomsheet/details/BottomSheetDetailsContent.kt
+++ b/app/src/main/java/com/app/whakaara/ui/bottomsheet/details/BottomSheetDetailsContent.kt
@@ -1,4 +1,4 @@
-package com.app.whakaara.ui.bottomsheet
+package com.app.whakaara.ui.bottomsheet.details
 
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.gestures.detectTapGestures
@@ -30,7 +30,7 @@ import kotlinx.coroutines.launch
 import java.util.Calendar
 
 @Composable
-fun BottomSheetContent(
+fun BottomSheetDetailsContent(
     modifier: Modifier = Modifier,
     alarm: Alarm,
     timeToAlarm: String,
@@ -65,7 +65,7 @@ fun BottomSheetContent(
                 )
             }
     ) {
-        BottomSheetTopBar(
+        BottomSheetDetailsTopBar(
             coroutineScope = coroutineScope,
             sheetState = sheetState,
             alarm = alarm,
@@ -128,7 +128,7 @@ fun BottomSheetContent(
 @FontScalePreviews
 fun BottomSheetContentPreview() {
     WhakaaraTheme {
-        BottomSheetContent(
+        BottomSheetDetailsContent(
             alarm = Alarm(
                 date = Calendar.getInstance(),
                 isEnabled = false,

--- a/app/src/main/java/com/app/whakaara/ui/bottomsheet/details/BottomSheetDetailsTimePicker.kt
+++ b/app/src/main/java/com/app/whakaara/ui/bottomsheet/details/BottomSheetDetailsTimePicker.kt
@@ -1,4 +1,4 @@
-package com.app.whakaara.ui.bottomsheet
+package com.app.whakaara.ui.bottomsheet.details
 
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.LocalTextStyle

--- a/app/src/main/java/com/app/whakaara/ui/bottomsheet/details/BottomSheetDetailsTopBar.kt
+++ b/app/src/main/java/com/app/whakaara/ui/bottomsheet/details/BottomSheetDetailsTopBar.kt
@@ -1,4 +1,4 @@
-package com.app.whakaara.ui.bottomsheet
+package com.app.whakaara.ui.bottomsheet.details
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -38,7 +38,7 @@ import kotlinx.coroutines.launch
 import java.util.Calendar
 
 @Composable
-fun BottomSheetTopBar(
+fun BottomSheetDetailsTopBar(
     modifier: Modifier = Modifier,
     coroutineScope: CoroutineScope,
     sheetState: BottomSheetState,
@@ -143,7 +143,7 @@ private fun BottomSheetTitle(
 @Composable
 fun BottomSheetTopBarPreview() {
     WhakaaraTheme {
-        BottomSheetTopBar(
+        BottomSheetDetailsTopBar(
             coroutineScope = rememberCoroutineScope(),
             sheetState = BottomSheetState(),
             alarm = Alarm(

--- a/app/src/main/java/com/app/whakaara/ui/bottomsheet/details/BottomSheetDetailsWrapper.kt
+++ b/app/src/main/java/com/app/whakaara/ui/bottomsheet/details/BottomSheetDetailsWrapper.kt
@@ -1,4 +1,4 @@
-package com.app.whakaara.ui.bottomsheet
+package com.app.whakaara.ui.bottomsheet.details
 
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
@@ -7,7 +7,7 @@ import com.dokar.sheets.BottomSheet
 import com.dokar.sheets.BottomSheetState
 
 @Composable
-fun BottomSheetWrapper(
+fun BottomSheetDetailsWrapper(
     alarm: Alarm,
     timeToAlarm: String,
     is24HourFormat: Boolean,
@@ -19,7 +19,7 @@ fun BottomSheetWrapper(
         state = state,
         skipPeeked = true
     ) {
-        BottomSheetContent(
+        BottomSheetDetailsContent(
             alarm = alarm,
             timeToAlarm = timeToAlarm,
             is24HourFormat = is24HourFormat,

--- a/app/src/main/java/com/app/whakaara/ui/bottomsheet/settings/BottomSheetSettingsWrapper.kt
+++ b/app/src/main/java/com/app/whakaara/ui/bottomsheet/settings/BottomSheetSettingsWrapper.kt
@@ -1,0 +1,20 @@
+package com.app.whakaara.ui.bottomsheet.settings
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import com.dokar.sheets.BottomSheet
+import com.dokar.sheets.BottomSheetState
+
+@Composable
+fun BottomSheetSettingsWrapper(
+    state: BottomSheetState
+) {
+    BottomSheet(
+        backgroundColor = MaterialTheme.colorScheme.surface,
+        state = state,
+        skipPeeked = true
+    ) {
+        Text(text = "~~settings bottom sheet~~")
+    }
+}

--- a/app/src/main/java/com/app/whakaara/ui/card/Card.kt
+++ b/app/src/main/java/com/app/whakaara/ui/card/Card.kt
@@ -32,7 +32,7 @@ import androidx.compose.ui.unit.sp
 import com.app.whakaara.R
 import com.app.whakaara.data.alarm.Alarm
 import com.app.whakaara.state.PreferencesState
-import com.app.whakaara.ui.bottomsheet.BottomSheetWrapper
+import com.app.whakaara.ui.bottomsheet.details.BottomSheetDetailsWrapper
 import com.app.whakaara.ui.theme.FontScalePreviews
 import com.app.whakaara.ui.theme.Spacings.space100
 import com.app.whakaara.ui.theme.Spacings.space20
@@ -151,7 +151,7 @@ fun Card(
         }
     }
 
-    BottomSheetWrapper(
+    BottomSheetDetailsWrapper(
         alarm = alarm,
         timeToAlarm = timeToAlarm,
         is24HourFormat = preferencesState.preferences.is24HourFormat,

--- a/app/src/main/java/com/app/whakaara/ui/navigation/BottomNavItem.kt
+++ b/app/src/main/java/com/app/whakaara/ui/navigation/BottomNavItem.kt
@@ -1,13 +1,15 @@
 package com.app.whakaara.ui.navigation
 
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Notifications
-import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material.icons.filled.Timer
+import androidx.compose.material.icons.outlined.HourglassEmpty
+import androidx.compose.material.icons.outlined.Notifications
+import androidx.compose.material.icons.outlined.Settings
+import androidx.compose.material.icons.outlined.Timer
 import androidx.compose.ui.graphics.vector.ImageVector
 
 sealed class BottomNavItem(var title: String, var icon: ImageVector, var route: String) {
-    object Alarm : BottomNavItem(title = "Alarm", icon = Icons.Filled.Notifications, route = "alarm")
-    object Settings : BottomNavItem(title = "Settings", icon = Icons.Filled.Settings, route = "settings")
-    object Timer : BottomNavItem(title = "Timer", icon = Icons.Filled.Timer, route = "timer")
+    object Alarm : BottomNavItem(title = "Alarm", icon = Icons.Outlined.Notifications, route = "alarm")
+    object Settings : BottomNavItem(title = "Settings", icon = Icons.Outlined.Settings, route = "settings")
+    object Timer : BottomNavItem(title = "Timer", icon = Icons.Outlined.HourglassEmpty, route = "timer")
+    object Stopwatch : BottomNavItem(title = "Stopwatch", icon = Icons.Outlined.Timer, route = "stopwatch")
 }

--- a/app/src/main/java/com/app/whakaara/ui/navigation/BottomNavItem.kt
+++ b/app/src/main/java/com/app/whakaara/ui/navigation/BottomNavItem.kt
@@ -1,14 +1,14 @@
 package com.app.whakaara.ui.navigation
 
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Alarm
 import androidx.compose.material.icons.outlined.HourglassEmpty
-import androidx.compose.material.icons.outlined.Notifications
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material.icons.outlined.Timer
 import androidx.compose.ui.graphics.vector.ImageVector
 
 sealed class BottomNavItem(var title: String, var icon: ImageVector, var route: String) {
-    object Alarm : BottomNavItem(title = "Alarm", icon = Icons.Outlined.Notifications, route = "alarm")
+    object Alarm : BottomNavItem(title = "Alarm", icon = Icons.Outlined.Alarm, route = "alarm")
     object Settings : BottomNavItem(title = "Settings", icon = Icons.Outlined.Settings, route = "settings")
     object Timer : BottomNavItem(title = "Timer", icon = Icons.Outlined.HourglassEmpty, route = "timer")
     object Stopwatch : BottomNavItem(title = "Stopwatch", icon = Icons.Outlined.Timer, route = "stopwatch")

--- a/app/src/main/java/com/app/whakaara/ui/navigation/BottomNavigation.kt
+++ b/app/src/main/java/com/app/whakaara/ui/navigation/BottomNavigation.kt
@@ -6,6 +6,7 @@ import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.graphics.Color
 import androidx.navigation.NavController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
@@ -18,10 +19,12 @@ fun BottomNavigation(navController: NavController) {
     val navItems = listOf(
         BottomNavItem.Alarm,
         BottomNavItem.Timer,
-        BottomNavItem.Settings
+        BottomNavItem.Stopwatch
     )
 
-    NavigationBar {
+    NavigationBar(
+        containerColor = Color.Transparent
+    ) {
         val navBackStackEntry by navController.currentBackStackEntryAsState()
         val currentRoute = navBackStackEntry?.destination?.route
         navItems.forEach { item ->
@@ -31,8 +34,8 @@ fun BottomNavigation(navController: NavController) {
                 label = { Text(text = item.title) },
                 onClick = {
                     navController.navigate(item.route) {
-                        navController.graph.startDestinationRoute?.let { screen_route ->
-                            popUpTo(screen_route) {
+                        navController.graph.startDestinationRoute?.let { screenRoute ->
+                            popUpTo(screenRoute) {
                                 saveState = true
                             }
                         }

--- a/app/src/main/java/com/app/whakaara/ui/navigation/NavGraph.kt
+++ b/app/src/main/java/com/app/whakaara/ui/navigation/NavGraph.kt
@@ -1,5 +1,6 @@
 package com.app.whakaara.ui.navigation
 
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
@@ -44,6 +45,12 @@ fun NavGraph(
                 onPause = viewModel::pause,
                 onStop = viewModel::resetTimer
             )
+        }
+
+        composable(
+            route = BottomNavItem.Stopwatch.route
+        ) {
+            Text(text = "Stopwatch")
         }
 
         composable(

--- a/app/src/main/java/com/app/whakaara/ui/navigation/TopBar.kt
+++ b/app/src/main/java/com/app/whakaara/ui/navigation/TopBar.kt
@@ -1,27 +1,54 @@
 package com.app.whakaara.ui.navigation
 
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.navigation.compose.currentBackStackEntryAsState
-import androidx.navigation.compose.rememberNavController
+import androidx.compose.runtime.rememberCoroutineScope
+import com.app.whakaara.ui.bottomsheet.settings.BottomSheetSettingsWrapper
 import com.app.whakaara.ui.theme.FontScalePreviews
 import com.app.whakaara.ui.theme.ThemePreviews
 import com.app.whakaara.ui.theme.WhakaaraTheme
+import com.dokar.sheets.rememberBottomSheetState
+import kotlinx.coroutines.launch
+import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun TopBar(
     route: String
 ) {
+    val scope = rememberCoroutineScope()
+    val sheetState = rememberBottomSheetState()
+
     TopAppBar(
         title = {
             Text(
                 text = route
+                    .replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
             )
+        },
+        actions = {
+            when (route) {
+                "alarm" -> {
+                    IconButton(
+                        onClick = {
+                            scope.launch { sheetState.expand() }
+                        }
+                    ) {
+                        Icon(Icons.Outlined.Settings, contentDescription = "alarm settings")
+                    }
+                }
+            }
         }
+    )
+
+    BottomSheetSettingsWrapper(
+        state = sheetState
     )
 }
 
@@ -29,12 +56,9 @@ fun TopBar(
 @ThemePreviews
 @FontScalePreviews
 fun TopBarPreview() {
-    val navController = rememberNavController()
-    val navBackStackEntry by navController.currentBackStackEntryAsState()
-    navBackStackEntry?.destination?.route = "alarm"
     WhakaaraTheme {
         TopBar(
-            route = "Alarm"
+            route = "alarm"
         )
     }
 }

--- a/app/src/main/java/com/app/whakaara/ui/screens/MainScreen.kt
+++ b/app/src/main/java/com/app/whakaara/ui/screens/MainScreen.kt
@@ -32,7 +32,6 @@ import com.marosseleng.compose.material3.datetimepickers.time.domain.noSeconds
 import com.marosseleng.compose.material3.datetimepickers.time.ui.dialog.TimePickerDialog
 import java.time.LocalTime
 import java.util.Calendar
-import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -54,9 +53,7 @@ fun MainScreen(
     Scaffold(
         topBar = {
             TopBar(
-                route = navBackStackEntry?.destination?.route
-                    .toString()
-                    .replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.getDefault()) else it.toString() }
+                route = navBackStackEntry?.destination?.route.toString()
             )
         },
         bottomBar = { BottomNavigation(navController = navController) },


### PR DESCRIPTION
- Stopwatch in bottom navigation, routing enabled
- Settings icon in top app bar that opens a new bottom sheet(empty). Alarm settings will be moved here, out of the bottom nav bar
- Updated bottom nav bar icons

Current home screen:
<img width="298" alt="Screenshot 2024-01-11 at 9 55 15 PM" src="https://github.com/ahudson20/whakaara/assets/29796379/e943256a-bacc-477b-be6e-72cf3a9be675">
<img width="298" alt="Screenshot 2024-01-11 at 9 55 29 PM" src="https://github.com/ahudson20/whakaara/assets/29796379/7243e1b0-7c39-4ed0-95bc-029e9df1e18f">

New design of home screen from  @eviemcn :
<img width="299" alt="home-screen-empty" src="https://github.com/ahudson20/whakaara/assets/29796379/cf0a8667-1b89-4049-86ca-2101f9b5d86a">
